### PR TITLE
Fixes an issue where if the user credentials didn't have select on ce…

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -70,7 +70,7 @@ func (p *Postgres) Describe() (*domain.Description, error) {
       WHERE c.contype = 'p')
 
     select c.table_catalog, c.table_schema, c.table_name, c.column_name, CASE WHEN c.ordinal_position = ANY(o_1.column_positions) THEN true ELSE false END as "is_primary_key"
-        FROM o_1 LEFT JOIN information_schema.columns c
+        FROM o_1 INNER JOIN information_schema.columns c
             ON o_1.table_schema = c.table_schema
             AND o_1.table_name = c.table_name;
     `


### PR DESCRIPTION
…rtain tables, source would crash.

@vinceprignano 

the issue was that if the user credentials only had select access to some of the tables on the DB, it would appear in the left side of the join but not the right side and cause some random empty rows to appear and thus running the describe statement would crash the code. this change makes it so that the tables that cannot be read from are now ignored in the init phase and will _not_ appear in schema.json and thus ignored in the upload phase (which is what we want)

FYI also double verified this is the case in mysql as well for consistency.
